### PR TITLE
Fix build on Linux, fix Intellisense, add PlatformIO CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: PlatformIO CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Install CH32V platform
+        run: pio pkg install -g -p "https://github.com/Community-PIO-CH32V/platform-ch32v.git"
+
+      - name: Build CDCRenderer Firmware
+        run: cd CDCRenderer && pio run
+
+      - name: Build ClusterRaymarcher Firmware
+        run: cd ClusterRaymarcher && pio run
+
+      - name: Build ClusterRaymarcherBase Firmware
+        run: cd ClusterRaymarcherBase && pio run

--- a/ClusterRaymarcher/src/ClientBus.h
+++ b/ClusterRaymarcher/src/ClientBus.h
@@ -1,7 +1,7 @@
 #pragma	once
 #include <stdint.h>
 #include <ch32v00x.h>
-#include "Bus.h"
+#include "bus.h"
 
 class ClientBus: public Bus
 {

--- a/ClusterRaymarcher/src/adc.h
+++ b/ClusterRaymarcher/src/adc.h
@@ -1,3 +1,5 @@
+#include <ch32v00x.h>
+
 void adcInit()
 {
     ADC_InitTypeDef  ADC_InitStructure = {0};

--- a/ClusterRaymarcherBase/src/HostBus.h
+++ b/ClusterRaymarcherBase/src/HostBus.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "Bus.h"
+#include "bus.h"
 #include "timer.h"
 #include <stdint.h>
 


### PR DESCRIPTION
* build fails on case-sensitive systems because `#include "Bus.h"` and the file is named `bus.h`
* `adc.h` header did not include necessary headers before using types and functions
* adds [Github Actions CI](https://docs.platformio.org/en/latest/integration/ci/github-actions.html) to validate compilability of all firmwares